### PR TITLE
Fix name of first Securing Software module-2.2/1-web exercise

### DIFF
--- a/data/module-2/part-2/applications.md
+++ b/data/module-2/part-2/applications.md
@@ -332,7 +332,7 @@ Similarly to the previous part, these assignments are submitted to the Test My C
 
 </text-box>
 
-<programming-exercise name="Port Scanner" tmcname="Set2-01.Tasks">
+<programming-exercise name="Tasks" tmcname="Set2-01.Tasks">
 
 The assignment template has some functionality for adding tasks. Your task is
 to alter the loadTasks function so that the existing tasks are loaded when the


### PR DESCRIPTION
The name of the [first exercise](https://cybersecuritybase.mooc.fi/module-2.2/1-web#programming-exercise-port-scanner) should be "Tasks", but it's currently the same as the first exercise of the previous part/module ("Port Scanner"). This PR fixes the name.