### PR TITLE
Remove unnecessary HTML tag

### DIFF
--- a/data/module-2/part-2/applications.md
+++ b/data/module-2/part-2/applications.md
@@ -132,7 +132,7 @@ is used.
     <body>
 
         <article>
-            <input type="text" id="content" value="0"></input></p>
+            <input type="text" id="content" value="0" />
             <input type="button" value="Add!" onclick="increment();" />
         </article>
 


### PR DESCRIPTION
There is a closing `</p>` tag, although there is no opening `<p>` tag.