### PR TITLE
Broken link fixes

### DIFF
--- a/data/module-2/part-2/applications.md
+++ b/data/module-2/part-2/applications.md
@@ -295,11 +295,11 @@ the id "content".
 
 <text-box variant=emph name="On debugging Javascript applications">
 
-When building and analyzing Javascript applications, being able to debug them is crucial. Up to date browsers such as Google Chrome provide quite good tools for analyzing the application. See [Chrome DevTools](https://developers.google.com/web/tools/chrome-devtools/) for a start.
+When building and analyzing Javascript applications, being able to debug them is crucial. Up to date browsers such as Google Chrome provide quite good tools for analyzing the application. See [Chrome DevTools](https://developer.chrome.com/docs/devtools/overview/) for a start.
 
 When debugging your own applications, the very basic command is `console.log()`, which can be used to print out variable details and other information to the developer tools console. When the command `console.log("Hello world!");` is inserted into your Javascript code, the text "Hello world!" will be printed to the Developer tools console. When looking for problems in code, debugging using the console log is a good start.
 
-If you are familiar with debuggers and breakpoints in IDEs, similar functionality is available for browsers as well. See [Inspect and Debug Javascript](https://developers.google.com/web/tools/chrome-devtools/javascript/add-breakpoints) at Google Developers.
+If you are familiar with debuggers and breakpoints in IDEs, similar functionality is available for browsers as well. See [Inspect and Debug Javascript](https://developer.chrome.com/docs/devtools/javascript/) at Google Developers.
 
 </text-box>
 


### PR DESCRIPTION
-  The two links in the section ['On debugging Javascript applications'](https://cybersecuritybase.mooc.fi/module-2.2/1-web#:~:text=On%20debugging%20Javascript%20applications) lead to the same URL.
![image](https://user-images.githubusercontent.com/85186840/233080052-724cda1a-db95-44c9-921a-d871bdaf0f89.png)
- Changed them so they now redirect correctly to their respective URLs as intended.
- Additionally, there was an [issue](https://github.com/rage/cyber-security-base-19/issues/40) previously reported that these links were giving a 404 error. However, I believe this issue has been resolved.
